### PR TITLE
Replace sprintf with snprintf

### DIFF
--- a/RKDevice.cpp
+++ b/RKDevice.cpp
@@ -108,7 +108,7 @@ char* CRKDevice::GetLayerName()
 string CRKDevice::GetLayerString(DWORD dwLocationID)
 {
 	char szLocation[32] = "\0";
-	sprintf(szLocation, "%d-%d", dwLocationID >> 8, dwLocationID & 0xff);
+	snprintf(szLocation, sizeof(szLocation), "%d-%d", dwLocationID >> 8, dwLocationID & 0xff);
 	return szLocation;
 }
 

--- a/RKLog.cpp
+++ b/RKLog.cpp
@@ -76,7 +76,7 @@ bool CRKLog::Write(string text)
 	FILE *file=NULL;
 	time(&now);
 	localtime_r(&now, &timeNow);
-	sprintf(szDateTime, "%04d-%02d-%02d.txt", timeNow.tm_year + 1900, timeNow.tm_mon + 1, timeNow.tm_mday);
+	snprintf(szDateTime, sizeof(szDateTime), "%04d-%02d-%02d.txt", timeNow.tm_year + 1900, timeNow.tm_mon + 1, timeNow.tm_mday);
 	strName = m_path + m_name+szDateTime;
 
 	try {
@@ -84,7 +84,7 @@ bool CRKLog::Write(string text)
 		if (!file) {
 			return false;
 		}
-		sprintf(szDateTime, "%02d:%02d:%02d \t", timeNow.tm_hour, timeNow.tm_min, timeNow.tm_sec);
+		snprintf(szDateTime, sizeof(szDateTime), "%02d:%02d:%02d \t", timeNow.tm_hour, timeNow.tm_min, timeNow.tm_sec);
 		text = szDateTime + text + "\r\n";
 		fwrite(text.c_str(), 1, text.size() * sizeof(char), file);
 		fclose(file);
@@ -111,7 +111,7 @@ void CRKLog::PrintBuffer(string &strOutput, PBYTE lpBuffer, DWORD dwSize, UINT u
 	char strHex[32];
 	strOutput = "";
 	for (i = 0, count = 0; i < dwSize; i++, count++) {
-		sprintf(strHex, "%X", lpBuffer[i]);
+		snprintf(strHex, sizeof(strHex), "%X", lpBuffer[i]);
 		strOutput = strOutput + " " + strHex;
 		if (count >= uiLineCount) {
 			strOutput += "\r\n";

--- a/main.cpp
+++ b/main.cpp
@@ -71,39 +71,39 @@ void ProgressInfoProc(DWORD deviceLayer, ENUM_PROGRESS_PROMPT promptID, long lon
 	char szText[256];
 	switch (promptID) {
 	case TESTDEVICE_PROGRESS:
-		sprintf(szText, "Test Device total %lld, current %lld", totalValue, currentValue);
+		snprintf(szText, sizeof(szText), "Test Device total %lld, current %lld", totalValue, currentValue);
 		strInfoText = szText;
 		break;
 	case LOWERFORMAT_PROGRESS:
-		sprintf(szText, "Lowerformat Device total %lld, current %lld", totalValue, currentValue);
+		snprintf(szText, sizeof(szText), "Lowerformat Device total %lld, current %lld", totalValue, currentValue);
 		strInfoText = szText;
 		break;
 	case DOWNLOADIMAGE_PROGRESS:
-		sprintf(szText, "Download Image total %lldK, current %lldK", totalValue/1024, currentValue/1024);
+		snprintf(szText, sizeof(szText), "Download Image total %lldK, current %lldK", totalValue/1024, currentValue/1024);
 		strInfoText = szText;
 		break;
 	case CHECKIMAGE_PROGRESS:
-		sprintf(szText, "Check Image total %lldK, current %lldK", totalValue/1024, currentValue/1024);
+		snprintf(szText, sizeof(szText), "Check Image total %lldK, current %lldK", totalValue/1024, currentValue/1024);
 		strInfoText = szText;
 		break;
 	case TAGBADBLOCK_PROGRESS:
-		sprintf(szText, "Tag Bad Block total %lld, current %lld", totalValue, currentValue);
+		snprintf(szText, sizeof(szText), "Tag Bad Block total %lld, current %lld", totalValue, currentValue);
 		strInfoText = szText;
 		break;
 	case TESTBLOCK_PROGRESS:
-		sprintf(szText, "Test Block total %lld, current %lld", totalValue, currentValue);
+		snprintf(szText, sizeof(szText), "Test Block total %lld, current %lld", totalValue, currentValue);
 		strInfoText = szText;
 		break;
 	case ERASEFLASH_PROGRESS:
-		sprintf(szText, "Erase Flash total %lld, current %lld", totalValue, currentValue);
+		snprintf(szText, sizeof(szText), "Erase Flash total %lld, current %lld", totalValue, currentValue);
 		strInfoText = szText;
 		break;
 	case ERASESYSTEM_PROGRESS:
-		sprintf(szText, "Erase System partition total %lld, current %lld", totalValue, currentValue);
+		snprintf(szText, sizeof(szText), "Erase System partition total %lld, current %lld", totalValue, currentValue);
 		strInfoText = szText;
 		break;
 	case ERASEUSERDATA_PROGRESS:
-		sprintf(szText, "<LocationID=%x> Erase Userdata partition total %lld, current %lld", deviceLayer, totalValue, currentValue);
+		snprintf(szText, sizeof(szText), "<LocationID=%x> Erase Userdata partition total %lld, current %lld", deviceLayer, totalValue, currentValue);
 		strInfoText = szText;
 		break;
 	}
@@ -3303,7 +3303,7 @@ int main(int argc, char* argv[])
 	struct stat statBuf;
 
 	g_ConfigItemVec.clear();
-	sprintf(szProgramProcPath, "/proc/%d/exe", getpid());
+	snprintf(szProgramProcPath, sizeof(szProgramProcPath), "/proc/%d/exe", getpid());
 	if (readlink(szProgramProcPath, szProgramDir, 256) == -1)
 		strcpy(szProgramDir, ".");
 	else {


### PR DESCRIPTION
`sprintf` is deprecated in newer compiles like use on macOS for security reasons. This updates all instances with the safer `snprintf`